### PR TITLE
Security Hardening: Mitigate XXE Vulnerabilities in JavaProvider and Restrict Actuator Endpoints

### DIFF
--- a/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/providers/impl/JavaProvider.java
+++ b/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/providers/impl/JavaProvider.java
@@ -93,6 +93,12 @@ public class JavaProvider extends LanguageProvider {
 
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            // Prevent XXE attacks
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.newDocument();
 
@@ -156,6 +162,9 @@ public class JavaProvider extends LanguageProvider {
                     .appendChild(pluginElement);
 
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            // Restrict external access in transformer to prevent XXE
+            transformerFactory.setAttribute(javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            transformerFactory.setAttribute(javax.xml.XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
             Transformer transformer = transformerFactory.newTransformer();
             transformer.setOutputProperty("indent", "yes");
             DOMSource source = new DOMSource(doc);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,8 @@ spring.data.mongodb.authentication-database=admin
 
 management.server.port=9080
 management.endpoints.access.default=read-only
-management.endpoints.web.exposure.include=*
+## Restrict actuator endpoints to only health, info, and prometheus
+management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.env.access=read-only
 management.endpoint.health.access=read-only
 management.endpoint.health.group.live.include=diskSpace


### PR DESCRIPTION
This merge request addresses several critical security issues:

1. **XML External Entity (XXE) Mitigation in JavaProvider.java**
   - The `DocumentBuilderFactory` is now securely configured by disabling DOCTYPE declarations and external entity processing, mitigating XXE attacks.
   - The `TransformerFactory` is partially secured by setting the `accessExternalDTD` and `accessExternalStylesheet` attributes to "". However, a related issue remains regarding DOCTYPE declarations in the `TransformerFactory` (see below).

2. **Spring Boot Actuator Endpoint Security**
   - The `application.properties` file has been updated to restrict actuator endpoint exposure, reducing the risk of sensitive information leakage.

**Remaining Issue:**
- There is still a security concern regarding the `TransformerFactory` in `JavaProvider.java` (line 168), where DOCTYPE declarations are not fully disabled. This should be addressed in a future update, but the current changes significantly reduce the attack surface and improve overall security posture.

**Recommendation:**
- Merge these changes to immediately improve security, while tracking the remaining TransformerFactory issue for further remediation.