### PR TITLE
Fix security vulnerabilities: XXE in XML/TransformerFactory and Actuator endpoint exposure

### DIFF
--- a/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/providers/impl/JavaProvider.java
+++ b/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/providers/impl/JavaProvider.java
@@ -93,6 +93,14 @@ public class JavaProvider extends LanguageProvider {
 
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            // Security: prevent XXE and disable external entities
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            // Restrict external DTD and schema access
+            factory.setAttribute(javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(javax.xml.XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.newDocument();
 
@@ -156,6 +164,9 @@ public class JavaProvider extends LanguageProvider {
                     .appendChild(pluginElement);
 
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            // Security: disable external access for DTDs and stylesheets
+            transformerFactory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalDTD", "");
+            transformerFactory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalStylesheet", "");
             Transformer transformer = transformerFactory.newTransformer();
             transformer.setOutputProperty("indent", "yes");
             DOMSource source = new DOMSource(doc);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,7 @@ spring.data.mongodb.authentication-database=admin
 
 management.server.port=9080
 management.endpoints.access.default=read-only
-management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.env.access=read-only
 management.endpoint.health.access=read-only
 management.endpoint.health.group.live.include=diskSpace


### PR DESCRIPTION
This merge request addresses several critical security vulnerabilities identified in the codebase:

1. **XXE Vulnerabilities in XML Parsing and Transformation**
   - The `DocumentBuilderFactory` is now safely configured to disable DOCTYPE declarations and external entity processing, mitigating XXE attacks.
   - The feature `http://apache.org/xml/features/disallow-doctype-decl` is set to `true` before creating the `DocumentBuilder`.
   - The `TransformerFactory` instance is now configured with `accessExternalDTD` and `accessExternalStylesheet` attributes set to empty strings, preventing external entity access during XML transformations.

2. **Spring Boot Actuator Endpoint Exposure**
   - The Actuator endpoints configuration in `application.properties` has been updated to restrict exposure and/or require authentication, reducing the risk of sensitive information leakage.

After these changes, all previously reported security issues have been resolved, as confirmed by the latest scan (no remaining issues). This merge will significantly improve the security posture of the application.