### PR TITLE
Security Hardening: Address XXE Vulnerabilities in XML and Transformers

### DIFF
--- a/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/providers/impl/JavaProvider.java
+++ b/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/providers/impl/JavaProvider.java
@@ -93,6 +93,11 @@ public class JavaProvider extends LanguageProvider {
 
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            // Secure XML processing to prevent XXE
+            factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.newDocument();
 
@@ -156,6 +161,9 @@ public class JavaProvider extends LanguageProvider {
                     .appendChild(pluginElement);
 
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            // Secure TransformerFactory to prevent external entity access
+            transformerFactory.setAttribute(javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            transformerFactory.setAttribute(javax.xml.XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
             Transformer transformer = transformerFactory.newTransformer();
             transformer.setOutputProperty("indent", "yes");
             DOMSource source = new DOMSource(doc);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,11 @@ spring.data.mongodb.authentication-database=admin
 
 management.server.port=9080
 management.endpoints.access.default=read-only
-management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.include=health,info,prometheus
+# Disable sensitive endpoints
+management.endpoint.env.enabled=false
+management.endpoint.heapdump.enabled=false
+management.endpoint.shutdown.enabled=false
 management.endpoint.env.access=read-only
 management.endpoint.health.access=read-only
 management.endpoint.health.group.live.include=diskSpace


### PR DESCRIPTION
This merge request addresses multiple security vulnerabilities related to XML External Entity (XXE) attacks found in the codebase. The following improvements were made:

1. DocumentBuilderFactory is now configured with secure processing, DOCTYPE declarations are disallowed, and external entities are disabled at the points previously flagged as vulnerable.
2. Spring Boot Actuator endpoints are now more tightly secured, restricting access to sensitive endpoints such as /actuator/env and /actuator/heapdump.

However, note that one issue remains regarding TransformerFactory's handling of "accessExternalDTD" and "accessExternalStylesheet", which is not fully resolved within this patch. Subsequent work is needed at line 167 of JavaProvider.java to disable these features as recommended.

Despite the one remaining vulnerability, these changes significantly raise the project’s security baseline by closing all but one of the previously identified critical vulnerabilities. Merging is recommended to reduce the attack surface while work continues on the last issue.