### PR TITLE
Fix security vulnerabilities: Secure XML Parser, TransformerFactory and restrict Actuator exposure

### DIFF
--- a/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/providers/impl/JavaProvider.java
+++ b/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/providers/impl/JavaProvider.java
@@ -14,6 +14,7 @@ import java.util.regex.Pattern;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.XMLConstants;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
@@ -93,6 +94,15 @@ public class JavaProvider extends LanguageProvider {
 
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            // Secure DocumentBuilderFactory against XXE
+            try {
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            } catch (ParserConfigurationException e) {
+                throw new RuntimeException("Failed to configure XML parser securely", e);
+            }
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.newDocument();
 
@@ -156,6 +166,13 @@ public class JavaProvider extends LanguageProvider {
                     .appendChild(pluginElement);
 
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            // Secure TransformerFactory against XXE
+            try {
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            } catch (IllegalArgumentException e) {
+                // Ignore if not supported
+            }
             Transformer transformer = transformerFactory.newTransformer();
             transformer.setOutputProperty("indent", "yes");
             DOMSource source = new DOMSource(doc);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,7 @@ spring.data.mongodb.authentication-database=admin
 
 management.server.port=9080
 management.endpoints.access.default=read-only
-management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.include=health,info
 management.endpoint.env.access=read-only
 management.endpoint.health.access=read-only
 management.endpoint.health.group.live.include=diskSpace


### PR DESCRIPTION
This merge request addresses the following security issues:
- Configured DocumentBuilderFactory securely to prevent XXE (XML External Entity) vulnerabilities by setting features such as 'disallow-doctype-decl' and 'FEATURE_SECURE_PROCESSING'.
- Disabled DOCTYPE declarations for DocumentBuilderFactory to mitigate XML external entity attacks.
- Set 'accessExternalDTD' and 'accessExternalStylesheet' attributes on TransformerFactory to empty strings, disabling external DTD and stylesheet access and preventing XXE.
- Restricted Spring Boot Actuator endpoint exposure in 'application.properties' by not including all endpoints with '*', ensuring sensitive endpoints are not exposed without authentication.

After these changes, a scan confirms that all previously identified security issues have been resolved. No related vulnerabilities remain.

Please review and merge to improve codebase security.