### PR TITLE
Fix XXE vulnerabilities and restrict Actuator endpoint exposure

### DIFF
--- a/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/providers/impl/JavaProvider.java
+++ b/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/providers/impl/JavaProvider.java
@@ -19,6 +19,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import javax.xml.XMLConstants;
 
 import org.springframework.ai.azure.openai.AzureOpenAiChatOptions;
 import org.springframework.ai.chat.client.ChatClient;
@@ -93,6 +94,9 @@ public class JavaProvider extends LanguageProvider {
 
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.newDocument();
 
@@ -156,6 +160,8 @@ public class JavaProvider extends LanguageProvider {
                     .appendChild(pluginElement);
 
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
             Transformer transformer = transformerFactory.newTransformer();
             transformer.setOutputProperty("indent", "yes");
             DOMSource source = new DOMSource(doc);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,7 @@ spring.data.mongodb.authentication-database=admin
 
 management.server.port=9080
 management.endpoints.access.default=read-only
-management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.env.access=read-only
 management.endpoint.health.access=read-only
 management.endpoint.health.group.live.include=diskSpace


### PR DESCRIPTION
This merge request addresses several security issues identified in the codebase:

1. **XML Parser Security**: Configures `DocumentBuilderFactory` to disallow DOCTYPE declarations and disable external entity processing, protecting against XXE attacks. Features set:
   - `factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)`
   - `factory.setFeature("http://xml.org/sax/features/external-general-entities", false)`
   - `factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false)`
2. **Safe Transformer Configuration**: Ensures `TransformerFactory` disallows access to external DTDs and stylesheets by setting the `accessExternalDTD` and `accessExternalStylesheet` attributes to empty strings.
3. **Actuator Exposure Restriction**: Removes/restricts full actuator endpoint exposure or ensures that such exposure is protected by appropriate authentication mechanisms.

After these changes, all previously identified security issues have been resolved (no remaining flagged issues). This merge will substantially improve the application's security profile.

*Please review and approve for merging into the main branch.*