### PR TITLE
Prevent Sensitive Data Exposure in Logging

### DIFF
--- a/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/CodeService.java
+++ b/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/CodeService.java
@@ -193,7 +193,8 @@ public class CodeService {
             prepareCommands.add(CD_TO_INPUT_COMMAND);
             prepareCommands.add("rm -rf " + REMOTE_OUTPUT_PATH + "/*");
             prepareCommands.addAll(languageProvider.getPrepareExecutionCommands(workspaceFolder));
-            LoggingResultCallback prepareResult = dockerService.runInContainer(containerId, prepareCommands, true,
+            // run prepare-phase without logging stdout/stderr to avoid exposing code or errors
+            LoggingResultCallback prepareResult = dockerService.runInContainer(containerId, prepareCommands, false,
                     language.name());
             // return early for errors raised by prepare phase
             if (StringUtils.hasText(prepareResult.getStdErr())) {

--- a/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/DockerService.java
+++ b/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/DockerService.java
@@ -149,7 +149,8 @@ public class DockerService {
     }
 
     public LoggingResultCallback startContainer(String containerId, String logTag) {
-        LoggingResultCallback resultCallback = new LoggingResultCallback(true, logTag);
+        // Disable logging of container startup output to avoid exposing sensitive data
+        LoggingResultCallback resultCallback = new LoggingResultCallback(false, logTag);
 
         dockerClient
                 .startContainerCmd(containerId)


### PR DESCRIPTION
### Summary
This merge request addresses the security concern of sensitive data exposure through logging. The following changes have been made:

- In `CodeService.java`, the `runInContainer` method for the prepare phase is now called with logging disabled (`false`), ensuring that stdout/stderr (which may contain sensitive code or error details) are not logged.
- In `DockerService.java`, container startup logging is disabled by default to prevent any sensitive output from being captured in logs.

### Rationale
These changes ensure that potentially sensitive information, such as user code or error messages, is not inadvertently exposed through application logs. This is in line with best practices for secure coding and data privacy.

### Impact
- Reduces the risk of leaking sensitive data via logs.
- No impact on core functionality or user experience.

Please review and merge if appropriate.