### PR TITLE
Suppress sensitive framework logs in logback-spring.xml

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -10,6 +10,10 @@
             <pattern>%black(%d{ISO8601} %-36.36logger{36}) %highlight(%-5level) %msg%n%throwable</pattern>
         </encoder>
     </appender>
+    <!-- suppress potentially sensitive framework logs to avoid leaking details -->
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="org.apache.http" level="WARN"/>
+    <logger name="org.springframework.web" level="WARN"/>
 
     <root level="info">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
This change updates the logback-spring.xml configuration to suppress potentially sensitive logs from common frameworks (com.github.dockerjava, org.apache.http, org.springframework.web) by setting their log level to WARN. This reduces the risk of exposing sensitive data through logging, in line with the provided instructions. No application logic was changed; only logging configuration was updated.