### PR TITLE
Mask sensitive data in log output to prevent exposure

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -7,7 +7,8 @@
 
     <appender name="STDOUT" class="ConsoleAppender">
         <encoder class="PatternLayoutEncoder">
-            <pattern>%black(%d{ISO8601} %-36.36logger{36}) %highlight(%-5level) %msg%n%throwable</pattern>
+            <!-- Mask sensitive data (passwords, tokens, API keys, etc.) in log messages -->
+            <pattern>%black(%d{ISO8601} %-36.36logger{36}) %highlight(%-5level) %replace(%msg){'(?i)(password|passwd|pwd|secret|token|api[_-]?key|access[_-]?token|credential|ssn)(=|:)?[^\s,]+' ,'$1$2******'}%n%throwable</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
### Summary
This merge request updates the logback-spring.xml configuration to mask sensitive data in log messages, such as passwords, tokens, API keys, and similar credentials. This is achieved by using a regex replacement in the log pattern, which replaces the values of sensitive fields with asterisks (******).

### Details
- The log pattern now includes a `%replace` function that matches common sensitive field names (password, token, api_key, etc.) and replaces their values with `******`.
- This helps prevent accidental exposure of sensitive information through application logs.

### Why this is important
Logging sensitive data can lead to security vulnerabilities and data leaks. This change ensures that such data is masked in logs, improving the security posture of the application.

---
**Closes security concern: Ensure no sensitive data are exposed through logging.**