### PR TITLE
Prevent sensitive data exposure in DockerService logging

### DIFF
--- a/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/DockerService.java
+++ b/src/main/java/it/aci/ai/mcp/servers/code_interpreter/services/DockerService.java
@@ -148,14 +148,18 @@ public class DockerService {
         return createContainerResponse.getId();
     }
 
+    /**
+     * Start the container without logging its internal stdout/stderr to prevent leakage of sensitive data.
+     */
     public LoggingResultCallback startContainer(String containerId, String logTag) {
-        LoggingResultCallback resultCallback = new LoggingResultCallback(true, logTag);
+        // disable logging of container output by default for security
+        LoggingResultCallback resultCallback = new LoggingResultCallback(false, logTag);
 
         dockerClient
                 .startContainerCmd(containerId)
                 .exec();
 
-        // log stdout and stderr
+        // stream container stdout and stderr internally without logging
         dockerClient
                 .logContainerCmd(containerId)
                 .withStdErr(true)


### PR DESCRIPTION
### Summary
This merge request addresses the security concern of sensitive data exposure through logging in the `DockerService` class.

### Changes
- The `startContainer` method now disables logging of container stdout/stderr by default by setting the `LoggingResultCallback` to not log output (`new LoggingResultCallback(false, logTag)`).
- Updated comments to clarify that container output is no longer logged to prevent leakage of sensitive data.

### Rationale
Previously, container stdout and stderr were logged, which could inadvertently expose sensitive information. With this change, logs are suppressed by default, aligning with the instruction to ensure no sensitive data are exposed through logging.

### Impact
- Improves security by preventing sensitive data from being written to logs.
- Maintains internal streaming of container output if needed, but without logging.

No breaking changes are introduced, and the modification directly addresses the stated security requirement.