### PR TITLE
Remove stacktrace from logs to prevent sensitive data exposure

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -7,7 +7,8 @@
 
     <appender name="STDOUT" class="ConsoleAppender">
         <encoder class="PatternLayoutEncoder">
-            <pattern>%black(%d{ISO8601} %-36.36logger{36}) %highlight(%-5level) %msg%n%throwable</pattern>
+            <!-- Removed stacktrace to prevent sensitive data exposure in logs -->
+            <pattern>%black(%d{ISO8601} %-36.36logger{36}) %highlight(%-5level) %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
This change updates the logback-spring.xml configuration to remove stacktraces from being logged by default. By eliminating the %throwable pattern from the log output, the risk of exposing sensitive data through exception stacktraces in logs is reduced, aligning with the instruction to ensure no sensitive data are exposed through logging.