### PR TITLE
Remove stack traces from logs to prevent sensitive data exposure

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -7,7 +7,8 @@
 
     <appender name="STDOUT" class="ConsoleAppender">
         <encoder class="PatternLayoutEncoder">
-            <pattern>%black(%d{ISO8601} %-36.36logger{36}) %highlight(%-5level) %msg%n%throwable</pattern>
+            <!-- Removed %throwable to prevent sensitive data exposure -->
+            <pattern>%black(%d{ISO8601} %-36.36logger{36}) %highlight(%-5level) %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
This change updates the logback-spring.xml configuration to remove the '%throwable' pattern from the log output. By doing so, stack traces and exception details—which may contain sensitive data—are no longer printed to the logs. This directly addresses the instruction to ensure no sensitive data are exposed through logging.